### PR TITLE
Update usage of taxonomies in editQuestion

### DIFF
--- a/classes/class.TestInfoPageQuestionGUI.php
+++ b/classes/class.TestInfoPageQuestionGUI.php
@@ -11,6 +11,7 @@ require_once('./Services/AdvancedEditing/classes/class.ilObjAdvancedEditing.php'
  *
  * @ilCtrl_IsCalledBy TestInfoPageQuestionGUI: ilObjQuestionPoolGUI, ilObjTestGUI
  * @ilCtrl_IsCalledBy TestInfoPageQuestionGUI: ilQuestionEditGUI, ilTestExpressPageObjectGUI
+ * @ilCtrl_Calls TestInfoPageQuestionGUI: ilFormPropertyDispatchGUI
  */
 class TestInfoPageQuestionGUI extends assQuestionGUI {
 

--- a/plugin.php
+++ b/plugin.php
@@ -1,6 +1,6 @@
 <?php
 $id = 'infopageta';
-$version = '1.2.0';
+$version = '1.2.1';
 $ilias_min_version = '5.2.0';
 $ilias_max_version = '5.2.999';
 $responsible = 'PHZH';


### PR DESCRIPTION
Integration of taxonomies while creating or editing a question changed and qst-plugins became unusable in pools with active taxonomies. 